### PR TITLE
Merge in name changes to indicate graded assignment metrics.

### DIFF
--- a/figures/tasks.py
+++ b/figures/tasks.py
@@ -198,7 +198,7 @@ def populate_daily_metrics(site_id=None, date_for=None, force_update=False):
 
     do_update_enrollment_data = False if date_for < today else True
     if site_id is not None:
-        sites = get_sites_by_id((site_id, ))
+        sites = get_sites_by_id(site_id)
     else:
         sites = get_sites()
     sites_count = sites.count()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1489,6 +1489,16 @@
             "locate-path": "^3.0.0"
           }
         },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        },
         "get-stream": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -1581,6 +1591,7 @@
             "@jest/types": "^24.8.0",
             "anymatch": "^2.0.0",
             "fb-watchman": "^2.0.0",
+            "fsevents": "^1.2.7",
             "graceful-fs": "^4.1.15",
             "invariant": "^2.2.4",
             "jest-serializer": "^24.4.0",
@@ -3700,6 +3711,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -4158,6 +4178,7 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -4359,6 +4380,16 @@
                 "is-extendable": "^0.1.0"
               }
             }
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
           }
         },
         "glob-parent": {
@@ -6459,6 +6490,12 @@
         "schema-utils": "^0.3.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -6622,6 +6659,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
     },
     "fstream": {
       "version": "1.0.12",
@@ -8726,6 +8769,7 @@
         "@jest/types": "^24.8.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.4.0",
@@ -8908,6 +8952,16 @@
                 "is-extendable": "^0.1.0"
               }
             }
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
           }
         },
         "is-accessor-descriptor": {
@@ -10907,6 +10961,310 @@
         "true-case-path": "^1.0.2"
       }
     },
+    "node-sass-chokidar": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/node-sass-chokidar/-/node-sass-chokidar-1.5.0.tgz",
+      "integrity": "sha512-Ss7PbeKd1OmJGzWVObBjoYeqgVIi0S0w7b9Ryx+cC2+c2UwU2VL4ODxLJoXC8LBzMJNmKHlCHQ1gRRNXQRTLjQ==",
+      "requires": {
+        "async-foreach": "^0.1.3",
+        "chokidar": "^3.4.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "meow": "^3.7.0",
+        "node-sass": "^4.14.1",
+        "sass-graph": "^2.2.4",
+        "stdout-stream": "^1.4.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "anymatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+          "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
+        "chokidar": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+          "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+          "requires": {
+            "anymatch": "~3.1.2",
+            "braces": "~3.0.2",
+            "fsevents": "~2.3.2",
+            "glob-parent": "~5.1.2",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.6.0"
+          }
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "is-glob": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "node-sass": {
+          "version": "4.14.1",
+          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
+          "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
+          "requires": {
+            "async-foreach": "^0.1.3",
+            "chalk": "^1.1.1",
+            "cross-spawn": "^3.0.0",
+            "gaze": "^1.0.0",
+            "get-stdin": "^4.0.1",
+            "glob": "^7.0.3",
+            "in-publish": "^2.0.0",
+            "lodash": "^4.17.15",
+            "meow": "^3.7.0",
+            "mkdirp": "^0.5.1",
+            "nan": "^2.13.2",
+            "node-gyp": "^3.8.0",
+            "npmlog": "^4.0.0",
+            "request": "^2.88.0",
+            "sass-graph": "2.2.5",
+            "stdout-stream": "^1.4.0",
+            "true-case-path": "^1.0.2"
+          },
+          "dependencies": {
+            "sass-graph": {
+              "version": "2.2.5",
+              "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
+              "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
+              "requires": {
+                "glob": "^7.0.0",
+                "lodash": "^4.0.0",
+                "scss-tokenizer": "^0.2.3",
+                "yargs": "^13.3.2"
+              }
+            }
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "readdirp": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+          "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -11460,6 +11818,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
     },
     "pify": {
       "version": "2.3.0",
@@ -15789,6 +16152,7 @@
           "requires": {
             "anymatch": "^1.3.0",
             "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
             "glob-parent": "^2.0.0",
             "inherits": "^2.0.1",
             "is-binary-path": "^1.0.0",
@@ -15818,6 +16182,17 @@
             "p-map": "^1.1.1",
             "pify": "^3.0.0",
             "rimraf": "^2.2.8"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
           }
         },
         "globby": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "moment": "^2.22.1",
     "multiselect-react-dropdown": "^1.5.7",
     "node-sass": "^4.13.1",
+    "node-sass-chokidar": "^1.5.0",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "3.2.0",
     "postcss-loader": "^3.0.0",
@@ -82,6 +83,8 @@
     "build": "npm run build-rb10 && npm run build-rb16",
     "build-rb10": "REM_BASE=10 FIGURES_APP_BUILD=../figures/static/figures/rb10 node scripts/build.js",
     "build-rb16": "REM_BASE=16 FIGURES_APP_BUILD=../figures/static/figures/rb16 node scripts/build.js",
+    "build-css": "node-sass-chokidar src/ -o src/",
+    "watch-css": "npm run build-css && node-sass-chokidar src/ -o src/ --watch --recursive",
     "test": "node scripts/test.js --env=jsdom"
   },
   "jest": {

--- a/frontend/src/components/course-learners-list/CourseLearnersList.js
+++ b/frontend/src/components/course-learners-list/CourseLearnersList.js
@@ -55,9 +55,15 @@ class CourseLearnersList extends Component {
           <span className={styles['name']}><Link to={'/figures/user/' + user.getIn(['id'])}>{user.getIn(['name'])}</Link></span>
           <span className={styles['country']}>{countriesWithCodes[user.getIn(['country'], 'ND')]}</span>
           <span className={styles['date-enrolled']}>{moment(courseSpecificData.getIn(['date_enrolled'])).format('LL')}</span>
-          <span className={styles['course-progress']}>{(courseSpecificData.getIn(['progress_data', 'course_progress'], 0)*100).toFixed(2)}%</span>
           <span className={styles['course-completed']}>{courseSpecificData.getIn(['progress_data', 'course_completed'], false) && <FontAwesomeIcon icon={faCheck} className={styles['completed-icon']} />}</span>
           <span className={styles['date-completed']}>{courseSpecificData.getIn(['progress_data', 'course_completed'], false) ? moment(courseSpecificData.getIn(['progress_data', 'course_completed'])).format('LL') : '-'}</span>
+          <span className={styles['course-progress']}>{(courseSpecificData.getIn(['progress_data', 'course_progress'], 0)*100).toFixed(2)}%</span>
+          <span className={styles['course-progress-sections-completed']}>
+            {courseSpecificData.getIn(['progress_data', 'course_progress_details', 'sections_worked']) ? courseSpecificData.getIn(['progress_data', 'course_progress_details', 'sections_worked']).toFixed(1) : '-'}/{courseSpecificData.getIn(['progress_data', 'course_progress_details', 'sections_possible']) ? courseSpecificData.getIn(['progress_data', 'course_progress_details', 'sections_possible']).toFixed(1) : '-'}
+          </span>
+          <span className={styles['course-progress-points-earned']}>
+            {courseSpecificData.getIn(['progress_data', 'course_progress_details', 'points_earned']) ? courseSpecificData.getIn(['progress_data', 'course_progress_details', 'points_earned']).toFixed(1) : '-'}/{courseSpecificData.getIn(['progress_data', 'course_progress_details', 'points_possible']) ? courseSpecificData.getIn(['progress_data', 'course_progress_details', 'points_possible']).toFixed(1) : '-'}
+          </span>
         </li>
       )
     })
@@ -74,10 +80,12 @@ class CourseLearnersList extends Component {
             <li key="header" className={styles['header-row']}>
               <span className={styles['name']}>Learner</span>
               <span className={styles['country']}>Country</span>
-              <span className={styles['date-enrolled']}>Date enrolled</span>
-              <span className={styles['course-progress']}>Course progress</span>
-              <span className={styles['course-completed']}>Course completed</span>
-              <span className={styles['date-completed']}>Date completed</span>
+              <span className={styles['date-enrolled']}>Date Enrolled</span>
+              <span className={styles['course-completed']}>Course Completed</span>
+              <span className={styles['date-completed']}>Date Completed</span>
+              <span className={styles['course-progress']}>Graded Assignment Progress</span>
+              <span className={styles['course-progress-completed']}>Graded Assignments Completed</span>
+              <span className={styles['course-progress-earned']}>Graded Assignment Points Earned</span>
             </li>
             {learnersRender}
           </ul>

--- a/frontend/src/components/user-courses-list/UserCoursesList.js
+++ b/frontend/src/components/user-courses-list/UserCoursesList.js
@@ -39,18 +39,26 @@ class UserCoursesList extends Component {
             </li>
             <li className={styles['stat']}>
               <span className={styles['stat-label']}>
-                Points earned:
+                Graded Assignment Progress:
               </span>
               <span className={styles['stat-value']}>
-                {course.getIn(['progress_data', 'course_progress_details', 'points_earned'], 0)} (of {course.getIn(['progress_data', 'course_progress_details', 'points_possible'], 0)})
+                {(course.getIn(['progress_data', 'course_progress'], 0)*100).toFixed(2)}%
               </span>
             </li>
             <li className={styles['stat']}>
               <span className={styles['stat-label']}>
-                Overall progress:
+                Graded Assignments Completed:
               </span>
               <span className={styles['stat-value']}>
-                {(course.getIn(['progress_data', 'course_progress'], 0)*100).toFixed(2)}%
+                {course.getIn(['progress_data', 'course_progress_details', 'sections_worked']) ? course.getIn(['progress_data', 'course_progress_details', 'sections_worked']).toFixed(1) : '-'}/{course.getIn(['progress_data', 'course_progress_details', 'sections_possible']) ? course.getIn(['progress_data', 'course_progress_details', 'sections_possible']).toFixed(1) : '-'}
+              </span>
+            </li>
+            <li className={styles['stat']}>
+              <span className={styles['stat-label']}>
+                Graded Assignment Points Earned:
+              </span>
+              <span className={styles['stat-value']}>
+                {course.getIn(['progress_data', 'course_progress_details', 'points_earned']) ? course.getIn(['progress_data', 'course_progress_details', 'points_earned']).toFixed(1) : '-'}/{course.getIn(['progress_data', 'course_progress_details', 'points_possible']) ? course.getIn(['progress_data', 'course_progress_details', 'points_possible']).toFixed(1) : '-'}
               </span>
             </li>
           </ul>

--- a/frontend/src/components/user-courses-list/_user-courses-list.scss
+++ b/frontend/src/components/user-courses-list/_user-courses-list.scss
@@ -73,7 +73,7 @@
     .stat {
       flex-grow: 0;
       flex-shrink: 0;
-      width: 25%;
+      width: 20%;
       list-style-type: none;
       text-align: center;
 

--- a/frontend/src/views/CoursesList.js
+++ b/frontend/src/views/CoursesList.js
@@ -170,10 +170,10 @@ class CoursesList extends Component {
               </div>
             </div>
           </div>
-          <div className={styles['enrolments']}>
+          <div className={styles['enrollments']}>
             <div className={styles['in-cell-label-value']}>
               <div className={styles['mobile-label']}>
-                Enrolments:
+                Enrollments:
               </div>
               <div className={styles['mobile-value']}>
                 {metrics_enrollment_count}
@@ -262,8 +262,8 @@ class CoursesList extends Component {
                   ) : ''}
                 </button>
               </div>
-              <div className={styles['enrolments']}>
-                Enrolments:
+              <div className={styles['enrollments']}>
+                Enrollments:
               </div>
               <div className={styles['completions']}>
                 Completions:

--- a/frontend/src/views/ProgressOverview.js
+++ b/frontend/src/views/ProgressOverview.js
@@ -204,7 +204,7 @@ class ProgressOverview extends Component {
           const pointsEarned = (userProgress.getIn(['progress_details', 'points_earned'])) ? userProgress.getIn(['progress_details', 'points_earned']).toFixed(1) : '-';
           const pointsPossible = (userProgress.getIn(['progress_details', 'points_possible'])) ? userProgress.getIn(['progress_details', 'points_possible']).toFixed(1) : '-';
 
-          singleRecord[course.id] = `Progress: ${progressPercent}/1 | Sections: ${sectionsWorked}/${sectionsPossible} | Points: ${pointsEarned}/${pointsPossible}`;
+          singleRecord[course.id] = `Graded Assignment Progress: ${progressPercent}/1 | Graded Assignments: ${sectionsWorked}/${sectionsPossible} | Graded Assignment Points Earned: ${pointsEarned}/${pointsPossible}`;
         } else {
           singleRecord[course.id] = '-';
         };
@@ -267,16 +267,16 @@ class ProgressOverview extends Component {
           <div className={styles['single-course-progress']}>
             {userProgress ? [
               <div className={styles['data-group']}>
-                <span className={styles['data-label']}>Sections</span>
+                <span className={styles['data-label']}>Graded Assignment Progress</span>
+                <span className={styles['data']}>{(userProgress.getIn(['progress_percent'])*100).toFixed(0)}%</span>
+              </div>,
+              <div className={styles['data-group']}>
+                <span className={styles['data-label']}>Graded Assignments Completed</span>
                 <span className={styles['data']}>{userProgress.getIn(['progress_details', 'sections_worked']) ? userProgress.getIn(['progress_details', 'sections_worked']).toFixed(1) : '-'}/{userProgress.getIn(['progress_details', 'sections_possible']) ? userProgress.getIn(['progress_details', 'sections_possible']).toFixed(1) : '-'}</span>
               </div>,
               <div className={styles['data-group']}>
-                <span className={styles['data-label']}>Points</span>
+                <span className={styles['data-label']}>Graded Assignment Points Earned</span>
                 <span className={styles['data']}>{userProgress.getIn(['progress_details', 'points_earned']) ? userProgress.getIn(['progress_details', 'points_earned']).toFixed(1) : '-'}/{userProgress.getIn(['progress_details', 'points_possible']) ? userProgress.getIn(['progress_details', 'points_possible']).toFixed(1) : '-'}</span>
-              </div>,
-              <div className={styles['data-group']}>
-                <span className={styles['data-label']}>Progress</span>
-                <span className={styles['data']}>{(userProgress.getIn(['progress_percent'])*100).toFixed(0)}%</span>
               </div>
             ] : (
               <span className={styles['no-data']}>-</span>


### PR DESCRIPTION
- Fix daily metric pull with commit 69b5d58b2cca9f9d9e3b76f04745da1385d1f627. 
- Updated metric names for progress, sections completed, and section points earned to reflect `Graded Assignment` only with commit 27436e7d8297c7c35b018abaf711c4c84e18ca49.
The new course completion progress in this article https://support.edx.org/hc/en-us/articles/4402116362519-Why-does-my-Progress-page-look-different- represents more than just graded assignment progress which Figures includes currently. This pull request updates the current Figures metrics by renaming them to `Graded Assignments`.
Todo: Need to update Figures to reflect this new course completion progress which represents how much of the course content you have completed. That's not just graded assignments, but also readings, videos, or practice assignments.