### PR TITLE
fix: Make sure the completed fields are `certificate` named.

### DIFF
--- a/frontend/src/components/course-learners-list/CourseLearnersList.js
+++ b/frontend/src/components/course-learners-list/CourseLearnersList.js
@@ -81,8 +81,8 @@ class CourseLearnersList extends Component {
               <span className={styles['name']}>Learner</span>
               <span className={styles['country']}>Country</span>
               <span className={styles['date-enrolled']}>Date Enrolled</span>
-              <span className={styles['course-completed']}>Course Completed</span>
-              <span className={styles['date-completed']}>Date Completed</span>
+              <span className={styles['course-completed']}>Course Certificate Issued</span>
+              <span className={styles['date-completed']}>Course Certificate Date Issued</span>
               <span className={styles['course-progress']}>Graded Assignment Progress</span>
               <span className={styles['course-progress-completed']}>Graded Assignments Completed</span>
               <span className={styles['course-progress-earned']}>Graded Assignment Points Earned</span>


### PR DESCRIPTION
The `Course Completed` column was a little misleading as this represents the course certificate issued where the student has requested it. Some students may have passed the course and not requested a certificate of completion and therefore this fields would be blank.